### PR TITLE
fix: set direct chat's avatar url and create direct param

### DIFF
--- a/src/main/java/com/e_messenger/code/service/impl/ConversationQueryServiceImpl.java
+++ b/src/main/java/com/e_messenger/code/service/impl/ConversationQueryServiceImpl.java
@@ -50,7 +50,7 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
     private String getDirectChatAvatarUrl(String curUserId, List<Participant> participants){
         for(Participant participant : participants){
             if(!participant.getParticipantId().equals(curUserId)){
-                User other = userService.getUserByIdentifier(participant.getParticipantId());
+                User other = userService.getUserById(participant.getParticipantId());
                 return other.getAvatarUrl();
             }
         }
@@ -101,7 +101,12 @@ public class ConversationQueryServiceImpl implements ConversationQueryService {
     @Override
     public List<Participant> getParticipants(String groupId) {
         Conversation group = getConversationById(groupId, userService.getCurrentUser().getId());
-        return group.getParticipants();
+        List<Participant> result = group.getParticipants();
+        for(Participant x : result){
+            User user = userService.getUserById(x.getParticipantId());
+            x.setAvatarUrl(user.getAvatarUrl());
+        }
+        return result;
     }
 
     @Override

--- a/src/main/java/com/e_messenger/code/service/impl/DirectChatServiceImpl.java
+++ b/src/main/java/com/e_messenger/code/service/impl/DirectChatServiceImpl.java
@@ -39,7 +39,7 @@ public class DirectChatServiceImpl extends DirectChatService {
     @Override
     public Conversation createDirectChat(String otherId, Principal principal) {
         User actor = userService.getUserById(principal.getName());
-        User other = userService.getUserByIdentifier(otherId);
+        User other = userService.getUserById(otherId);
 
         if(actor.equals(other))
             throw new AppException(StatusCode.UNCATEGORIZED);


### PR DESCRIPTION
Fix lỗi khi set avatar cho direct chat: tìm kiếm bằng id thay vì phone number
Fix lỗi khi tạo direct: tham số là id của người muốn tạo chứ không phải phone number (việc này yêu cầu FE tạo direct theo đúng luồng: tìm user bằng SĐT/email,... khi có được id thì gửi để tạo conversation, linh hoạt hơn thay vì cố định tham số là SĐT)