### PR TITLE
fix: Kiểm tra để không thể gọi api group quản lý direct và ngược lại

### DIFF
--- a/src/main/java/com/e_messenger/code/controller/GroupChatController.java
+++ b/src/main/java/com/e_messenger/code/controller/GroupChatController.java
@@ -11,7 +11,9 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.security.Principal;
 import java.util.List;
 
@@ -37,6 +39,18 @@ public class GroupChatController {
         Conversation result = groupChatService.changeName(groupId, newName, principal);
         return ApiResponse.<ConversationResponse>builder()
                 .result(conversationMapper.toResponse(result))
+                .build();
+    }
+
+    @PutMapping("/{groupId}/avatars")
+    public ApiResponse<ConversationResponse> changeAvatar(
+            @PathVariable String groupId,
+            @RequestParam MultipartFile avatar,
+            Principal principal
+    ) throws IOException {
+        Conversation conv = groupChatService.changeAvatar(groupId, avatar, principal);
+        return ApiResponse.<ConversationResponse>builder()
+                .result(conversationMapper.toResponse(conv))
                 .build();
     }
 

--- a/src/main/java/com/e_messenger/code/service/ConversationService.java
+++ b/src/main/java/com/e_messenger/code/service/ConversationService.java
@@ -6,4 +6,5 @@ import java.security.Principal;
 
 public abstract class ConversationService {
     abstract public void deleteConversation(String conversationId, Principal principal);
+    abstract public void checkAvailable(Conversation conv);
 }


### PR DESCRIPTION
Thêm tính năng thay đổi conversation avatar (put /group/{groupId}/avatars 
Thêm trường kiểm tra khi gọi các api direct và group để không thể gọi chéo lẫn nhau